### PR TITLE
fix(api): update execution status streaming to use correct types and headers

### DIFF
--- a/src/julep/resources/executions/status.py
+++ b/src/julep/resources/executions/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import httpx
 
-from ..._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
+from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import (
@@ -13,6 +13,7 @@ from ..._response import (
     async_to_raw_response_wrapper,
     async_to_streamed_response_wrapper,
 )
+from ..._streaming import Stream, AsyncStream
 from ..._base_client import make_request_options
 from ...types.execution import Execution
 
@@ -82,7 +83,7 @@ class StatusResource(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-    ) -> None:
+    ) -> Stream[Execution]:
         """
         SSE endpoint that streams the status of a given execution_id by polling the
         latest_executions view.
@@ -98,13 +99,15 @@ class StatusResource(SyncAPIResource):
         """
         if not execution_id:
             raise ValueError(f"Expected a non-empty value for `execution_id` but received {execution_id!r}")
-        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
         return self._get(
             f"/executions/{execution_id}/status.stream",
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
-            cast_to=NoneType,
+            cast_to=Execution,
+            stream=True,
+            stream_cls=Stream[Execution],
         )
 
 
@@ -171,7 +174,7 @@ class AsyncStatusResource(AsyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-    ) -> None:
+    ) -> AsyncStream[Execution]:
         """
         SSE endpoint that streams the status of a given execution_id by polling the
         latest_executions view.
@@ -187,13 +190,15 @@ class AsyncStatusResource(AsyncAPIResource):
         """
         if not execution_id:
             raise ValueError(f"Expected a non-empty value for `execution_id` but received {execution_id!r}")
-        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
         return await self._get(
             f"/executions/{execution_id}/status.stream",
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
-            cast_to=NoneType,
+            cast_to=Execution,
+            stream=True,
+            stream_cls=AsyncStream[Execution],
         )
 
 

--- a/tests/api_resources/executions/test_status.py
+++ b/tests/api_resources/executions/test_status.py
@@ -9,8 +9,8 @@ import pytest
 
 from julep import Julep, AsyncJulep
 from julep.types import Execution
-from julep._streaming import Stream, AsyncStream
 from tests.utils import assert_matches_type
+from julep._streaming import Stream, AsyncStream
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 

--- a/tests/api_resources/executions/test_status.py
+++ b/tests/api_resources/executions/test_status.py
@@ -9,6 +9,7 @@ import pytest
 
 from julep import Julep, AsyncJulep
 from julep.types import Execution
+from julep._streaming import Stream, AsyncStream
 from tests.utils import assert_matches_type
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
@@ -60,7 +61,7 @@ class TestStatus:
         status = client.executions.status.stream(
             "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
         )
-        assert status is None
+        assert_matches_type(Stream[Execution], status, path=["response"])
 
     @parametrize
     def test_raw_response_stream(self, client: Julep) -> None:
@@ -71,7 +72,7 @@ class TestStatus:
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
         status = response.parse()
-        assert status is None
+        assert_matches_type(Stream[Execution], status, path=["response"])
 
     @parametrize
     def test_streaming_response_stream(self, client: Julep) -> None:
@@ -82,7 +83,7 @@ class TestStatus:
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 
             status = response.parse()
-            assert status is None
+            assert_matches_type(Stream[Execution], status, path=["response"])
 
         assert cast(Any, response.is_closed) is True
 
@@ -140,7 +141,7 @@ class TestAsyncStatus:
         status = await async_client.executions.status.stream(
             "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
         )
-        assert status is None
+        assert_matches_type(AsyncStream[Execution], status, path=["response"])
 
     @parametrize
     async def test_raw_response_stream(self, async_client: AsyncJulep) -> None:
@@ -151,7 +152,7 @@ class TestAsyncStatus:
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
         status = await response.parse()
-        assert status is None
+        assert_matches_type(AsyncStream[Execution], status, path=["response"])
 
     @parametrize
     async def test_streaming_response_stream(self, async_client: AsyncJulep) -> None:
@@ -162,7 +163,7 @@ class TestAsyncStatus:
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 
             status = await response.parse()
-            assert status is None
+            assert_matches_type(AsyncStream[Execution], status, path=["response"])
 
         assert cast(Any, response.is_closed) is True
 

--- a/tests/api_resources/executions/test_status.py
+++ b/tests/api_resources/executions/test_status.py
@@ -69,7 +69,7 @@ class TestStatus:
             "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
         )
 
-        assert response.is_closed is True
+        assert response.is_closed is False
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
         status = response.parse()
         assert_matches_type(Stream[Execution], status, path=["response"])
@@ -149,7 +149,7 @@ class TestAsyncStatus:
             "182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e",
         )
 
-        assert response.is_closed is True
+        assert response.is_closed is False
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
         status = await response.parse()
         assert_matches_type(AsyncStream[Execution], status, path=["response"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,6 +20,7 @@ from julep._utils import (
 )
 from julep._compat import PYDANTIC_V2, field_outer_type, get_model_fields
 from julep._models import BaseModel
+from julep._streaming import Stream, AsyncStream, is_stream_class_type, extract_stream_chunk_type
 
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
 
@@ -100,6 +101,18 @@ def assert_matches_type(
         for key, item in value.items():
             assert_matches_type(key_type, key, path=[*path, "<dict key>"])
             assert_matches_type(items_type, item, path=[*path, "<dict item>"])
+    elif is_stream_class_type(type_):
+        # Handle Stream[T] and AsyncStream[T] types
+        assert isinstance(value, (Stream, AsyncStream))
+        
+        # Verify the chunk type matches if we can extract it
+        try:
+            expected_chunk_type = extract_stream_chunk_type(type_)
+            # We can't easily check the actual chunk types without consuming the stream,
+            # so we just verify the stream instance is correct
+        except Exception:
+            # If we can't extract the chunk type, just verify it's a stream instance
+            pass
     elif is_union_type(type_):
         variants = get_args(type_)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,10 +104,10 @@ def assert_matches_type(
     elif is_stream_class_type(type_):
         # Handle Stream[T] and AsyncStream[T] types
         assert isinstance(value, (Stream, AsyncStream))
-        
+
         # Verify the chunk type matches if we can extract it
         try:
-            expected_chunk_type = extract_stream_chunk_type(type_)
+            extract_stream_chunk_type(type_)
             # We can't easily check the actual chunk types without consuming the stream,
             # so we just verify the stream instance is correct
         except Exception:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update execution status streaming to use correct types and headers, and adjust tests accordingly.
> 
>   - **Behavior**:
>     - Update `stream()` in `status.py` to return `Stream[Execution]` and `AsyncStream[Execution]`.
>     - Change `Accept` header to `text/event-stream` in `stream()` methods.
>   - **Tests**:
>     - Update assertions in `test_status.py` to check for `Stream[Execution]` and `AsyncStream[Execution]`.
>     - Ensure `response.is_closed` is `False` for streaming responses.
>   - **Utils**:
>     - Enhance `assert_matches_type()` in `utils.py` to handle `Stream` and `AsyncStream` types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fpython-sdk&utm_source=github&utm_medium=referral)<sup> for 1c771927165c43b146352db20e9ca073f8d70cf9. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->